### PR TITLE
Switch from TinyMCE to Markdown

### DIFF
--- a/src/controllers/posts/EditPost.php
+++ b/src/controllers/posts/EditPost.php
@@ -61,7 +61,7 @@ include BASE_PATH . "views/postsMenu.php";
 					<div class="form-group mb-0">
 						<label for="content">Content</label>
 						<textarea class="form-control" id="content" name="content"
-						rows="10"><?=$row['Content']?></textarea>
+						rows="10"><?=htmlspecialchars($row['Content'])?></textarea>
 						<small id="contentHelp" class="form-text text-muted">
 			        Styling may be stripped from this content
 			      </small>
@@ -151,21 +151,5 @@ include BASE_PATH . "views/postsMenu.php";
 	</form>
 </div>
 
-<script>
- tinymce.init({
-    selector: '#content',
-    branding: false,
-    plugins: [
-      'autolink lists link image charmap print preview anchor textcolor',
-      'searchreplace visualblocks code autoresize insertdatetime media table',
-      'contextmenu paste code help wordcount'
-    ],
-    toolbar: 'insert | undo redo |  formatselect | bold italic backcolor | alignleft aligncenter alignright alignjustify | bullist numlist outdent indent | removeformat | help',
-    content_css: [
-      'https://fonts.googleapis.com/css?family=Open+Sans:300,300i,400,400i',
-      '<?php echo autoUrl("css/tinymce.css"); ?>'
-    ]
-      //toolbar: "link",
- });
-</script>
+<script src="<?=autoUrl("public/js/posts/PostEditor.js")?>"></script>
 <?php include BASE_PATH . "views/footer.php";

--- a/src/controllers/posts/EditPost.php
+++ b/src/controllers/posts/EditPost.php
@@ -60,8 +60,7 @@ include BASE_PATH . "views/postsMenu.php";
 
 					<div class="form-group mb-0">
 						<label for="content">Content</label>
-						<textarea class="form-control" id="content" name="content"
-						rows="10"><?=htmlspecialchars($row['Content'])?></textarea>
+						<textarea class="form-control" id="content" name="content" onkeyup="autoGrow(this)"><?=htmlspecialchars($row['Content'])?></textarea>
 						<small id="contentHelp" class="form-text text-muted">
 			        Styling may be stripped from this content
 			      </small>

--- a/src/controllers/posts/NewPost.php
+++ b/src/controllers/posts/NewPost.php
@@ -25,7 +25,7 @@ include BASE_PATH . "views/postsMenu.php";
 						<textarea class="form-control" id="content" name="content" rows="10">
 			      </textarea>
 						<small id="contentHelp" class="form-text text-muted">
-			        Styling may be stripped from this content
+			        Use Markdown
 			      </small>
 					</div>
 
@@ -92,23 +92,5 @@ include BASE_PATH . "views/postsMenu.php";
 	</form>
 </div>
 
-<script>
- tinymce.init({
-    selector: '#content',
-    branding: false,
-    plugins: [
-      'autolink lists link image charmap print preview anchor textcolor',
-      'searchreplace visualblocks code autoresize insertdatetime media table',
-      'contextmenu paste code help wordcount'
-    ],
-    toolbar: 'insert | undo redo |  formatselect | bold italic backcolor | alignleft aligncenter alignright alignjustify | bullist numlist outdent indent | removeformat | help',
-    content_css: [
-      'https://fonts.googleapis.com/css?family=Open+Sans:300,300i,400,400i',
-      '<?php echo autoUrl("css/tinymce.css"); ?>'
-    ],
-    relative_urls : false,
-    remove_script_host : false
-      //toolbar: "link",
- });
-</script>
+<script src="<?=autoUrl("public/js/posts/PostEditor.js")?>"></script>
 <?php include BASE_PATH . "views/footer.php";

--- a/src/controllers/posts/NewPost.php
+++ b/src/controllers/posts/NewPost.php
@@ -22,7 +22,7 @@ include BASE_PATH . "views/postsMenu.php";
 
 					<div class="form-group mb-0">
 						<label for="content">Content</label>
-						<textarea class="form-control" id="content" name="content" rows="10">
+						<textarea class="form-control" id="content" name="content" onkeyup="autoGrow(this)">
 			      </textarea>
 						<small id="contentHelp" class="form-text text-muted">
 			        Use Markdown

--- a/src/controllers/posts/Post.php
+++ b/src/controllers/posts/Post.php
@@ -1,7 +1,12 @@
-<?
+<?php
 
 global $db;
 $query = null;
+
+$markdown = new ParsedownExtra();
+
+// Safe mode is disabled during the transition to markdown
+// $markdown->setSafeMode(true);
 
 if ($_SESSION['AccessLevel'] == 'Parent') {
   $sql = "SELECT COUNT(*) FROM `members` WHERE `UserID` = ?";
@@ -71,7 +76,7 @@ include BASE_PATH . "views/postsMenu.php";?>
 	<div class="row">
 		<div class="col-md-8">
 			<div id="post-content">
-				<?= $row['Content'] ?>
+				<?= $markdown->text($row['Content']) ?>
 			</div>
 		</div>
 	</div>

--- a/src/database.php
+++ b/src/database.php
@@ -1712,7 +1712,12 @@ function getPostContent($id) {
   if (!$row) {
     return false;
   }
-  return $row['Content'];
+
+  $markdown = new ParsedownExtra();
+  // Safe mode is disabled during the transition to markdown
+  // $markdown->setSafeMode(true);
+
+  return $markdown->text($row['Content']);
 }
 
 function isSubscribed($user, $email_type) {

--- a/src/public/js/posts/PostEditor.js
+++ b/src/public/js/posts/PostEditor.js
@@ -1,0 +1,6 @@
+function autoGrow(element) {
+  element.style.height = "5rem";
+  element.style.height = (element.scrollHeight+20)+"px";
+}
+
+autoGrow(document.getElementById('content'));


### PR DESCRIPTION
We're switching from TinyMCE to Markdown (with GFM support). This is because TinyMCE gives us all sorts of nasties in our HTML.

This is a MVP. Further improvements will make their way into production as we get feedback.