### PR TITLE
Changes so squad fees are now reported as individual payments

### DIFF
--- a/src/controllers/payments/admin/history/FinanceReport.json.php
+++ b/src/controllers/payments/admin/history/FinanceReport.json.php
@@ -5,9 +5,9 @@ require BASE_PATH . 'controllers/payments/GoCardlessSetup.php';
 /**
  * Exports of monthly financial reports
  * Shows payments by group and outgoings (GoCardless fees on payouts)
- * 
+ *
  * This means the system covers gross and net
- * 
+ *
  * TODO: Extend to cover Stripe card payments
  */
 
@@ -94,7 +94,7 @@ while ($row = $getPayments->fetch(PDO::FETCH_ASSOC)) {
       'details' => $details . ' - Total banked',
       'credits' => ((int) $in) - ((int) $out),
       'debits' => 0,
-      'income' => 'Gross',
+      'income' => 'Net',
       'status' => $status
     ];
     $array[] = $item;

--- a/src/controllers/payments/admin/history/FinanceReport.pdf.php
+++ b/src/controllers/payments/admin/history/FinanceReport.pdf.php
@@ -8,6 +8,7 @@ $items = $data->items;
 
 $pagetitle = 'Finance Report';
 
+$netCosts = $netIncome = 0;
 
 ob_start();?>
 
@@ -75,6 +76,10 @@ ob_start();?>
         <?php foreach ($items as $item) { ?>
         <?php
           $date = new DateTime($item->date);
+          if ($item->income == 'Net') {
+            $netIncome += $item->credits;
+            $netCosts += $item->debits;
+          }
         ?>
         <tr>
           <td>
@@ -104,6 +109,28 @@ ob_start();?>
           </td>
         </tr>
         <?php } ?>
+        <tr>
+          <td>
+          </td>
+          <td>
+            <strong>Total</strong>
+          </td>
+          <td>
+            Net Income
+          </td>
+          <td class="mono">
+            <?=number_format($netIncome/100, 2, '.', '')?>
+          </td>
+          <td class="mono">
+            <?=number_format($netCosts/100, 2, '.', '')?>
+          </td>
+          <td>
+            Net
+          </td>
+          <td>
+            Paid out
+          </td>
+        </tr>
       </tbody>
     </table>
 
@@ -122,7 +149,7 @@ ob_start();?>
 
     <p>Payments are handled by GoCardless on behalf of <?=htmlspecialchars(env('CLUB_NAME'))?>. You can also download reports from within the GoCardless user interface at <a href="https://manage.gocardless.com/">manage.gocardless.com</a>.</p>
 
-    <p>&copy; <?=htmlspecialchars(env('CLUB_NAME'))?> <?=date("Y", strtotime($data->date_produced))?></p>
+    <p>&copy; Swimming Club Data Systems <?=date("Y", strtotime($data->date_produced))?>. Produced for <?=htmlspecialchars(env('CLUB_NAME'))?>.</p>
 
     <?php include BASE_PATH . 'helperclasses/PDFStyles/PageNumbers.php'; ?>
   </body>

--- a/src/controllers/webhooks/chargeusers.php
+++ b/src/controllers/webhooks/chargeusers.php
@@ -80,6 +80,14 @@ try {
           'Payment',
           $date
         ]);
+        $updatePaymentsPending->execute([
+          'Requested',
+          $id,
+          $userid,
+          'Queued',
+          'Refund',
+          $date
+        ]);
 
     	} catch (Exception $e) {
       	halt(500);
@@ -103,6 +111,14 @@ try {
           $userid,
           'Queued',
           'Payment',
+          $date
+        ]);
+        $updatePaymentsPending->execute([
+          'Paid',
+          $id,
+          $userid,
+          'Queued',
+          'Refund',
           $date
         ]);
       } catch (Exception $e) {


### PR DESCRIPTION
This pull request changes the way payments for squad fees and extra fees are reported on monthly statements.

This means squad fees will no longer be shown as a single item on statements but instead as fees for each swimmer.

Extra fees will also no longer be shown as a single item on statements but instead as fees for each swimmer and extra.

Should a parent qualify for discounts, these will be added as a credit and shown much more clearly on the statement.

Changes have been tested in the dev environment.