### PR TITLE
Fix emergency contacts bug on reg/renewal

### DIFF
--- a/src/controllers/emergencycontacts/parents/new.php
+++ b/src/controllers/emergencycontacts/parents/new.php
@@ -12,6 +12,12 @@ $v = null;
 if (isset($_SESSION['POST_DATA'])) {
   $v = $_SESSION['POST_DATA'];
   unset($_SESSION['POST_DATA']);
+} else {
+  $v = [
+    'name' => '',
+    'relation' => '',
+    'num' => ''
+  ];
 }
 
 ?>

--- a/src/controllers/renewal/parent/emergencyContact.php
+++ b/src/controllers/renewal/parent/emergencyContact.php
@@ -84,8 +84,8 @@ include BASE_PATH . "views/renewalTitleBar.php";
                   </em>
 								</p>
 								<p class="mb-0">
-									<a href="tel:<?=htmlspecialchars($mobile->format(PhoneNumberFormat::RFC3966))?>">
-										<?=htmlspecialchars($mobile->format(PhoneNumberFormat::NATIONAL))?>
+									<a href="tel:<?=htmlspecialchars($contactsArray[$i]->getRFCContactNumber())?>">
+										<?=htmlspecialchars($contactsArray[$i]->getNationalContactNumber())?>
 									</a>
 								</p>
 							</div>

--- a/src/helperclasses/EmergencyContact.php
+++ b/src/helperclasses/EmergencyContact.php
@@ -18,7 +18,7 @@ class EmergencyContact {
 		// DO NOTHING
   }
 
-	public function new($name, $contactNumber, $user, $relation = null) {
+	public function new($name, $contactNumber, int $user, $relation = null) {
 		$this->name = ucwords($name);
 		try {
 			$number = \Brick\PhoneNumber\PhoneNumber::parse($contactNumber, 'GB');
@@ -36,7 +36,7 @@ class EmergencyContact {
 		}
   }
 
-	public function existing($contactId, $user, $name, $contactNumber, $relation = null) {
+	public function existing(int $contactId, int $user, $name, $contactNumber, $relation = null) {
 		$this->contactId = $contactId;
 		$this->user = $user;
 		$this->name = $name;
@@ -46,7 +46,7 @@ class EmergencyContact {
 		}
   }
 
-	public function getByContactID($contactId) {
+	public function getByContactID(int $contactId) {
 		$this->contactId = $contactId;
 		if ($this->dbconn == null) {
 			return false;

--- a/src/helperclasses/EmergencyContacts.php
+++ b/src/helperclasses/EmergencyContacts.php
@@ -9,10 +9,10 @@ class EmergencyContacts {
 		$this->dbconn = $dbconn;
 	}
 
-	public function byParent($id) {
+	public function byParent(int $id) {
     $sql = $this->dbconn->prepare("SELECT ID, UserID, `Name`, ContactNumber, `Relation` FROM `emergencyContacts` WHERE `UserID` = ?");
     $sql->execute([
-			(int) $id
+			$id
 		]);
 		while ($row = $sql->fetch(PDO::FETCH_ASSOC)) {
 			$new = new EmergencyContact();
@@ -28,7 +28,7 @@ class EmergencyContacts {
 	}
 
 	public function bySwimmer($id) {
-		$sql = $this->dbconn->prepare("SELECT ID, UserID, Name, ContactNumber FROM `members` LEFT JOIN `emergencyContacts` ON members.UserID = emergencyContacts.UserID WHERE `MemberID` = ?");
+		$sql = $this->dbconn->prepare("SELECT ID, UserID, `Name`, ContactNumber FROM `members` LEFT JOIN `emergencyContacts` ON members.UserID = emergencyContacts.UserID WHERE `MemberID` = ?");
     $sql->execute([$id]);
     while ($row = $sql->fetch(PDO::FETCH_ASSOC)) {
 			$new = new EmergencyContact();

--- a/src/helperclasses/EmergencyContacts.php
+++ b/src/helperclasses/EmergencyContacts.php
@@ -27,7 +27,7 @@ class EmergencyContacts {
 		}
 	}
 
-	public function bySwimmer($id) {
+	public function bySwimmer(int $id) {
 		$sql = $this->dbconn->prepare("SELECT ID, UserID, `Name`, ContactNumber FROM `members` LEFT JOIN `emergencyContacts` ON members.UserID = emergencyContacts.UserID WHERE `MemberID` = ?");
     $sql->execute([$id]);
     while ($row = $sql->fetch(PDO::FETCH_ASSOC)) {


### PR DESCRIPTION
Fixes a bug which displayed the registered user's contact number instead of those of emergency contacts during renewal/registration.

The bug did not cause any data to be overwritten.