### PR TITLE
Allow only one DD Mandate at once

### DIFF
--- a/src/controllers/payments/admin/history/statement.php
+++ b/src/controllers/payments/admin/history/statement.php
@@ -52,12 +52,30 @@ $pagetitle = "Statement for " . htmlspecialchars($name) . ", " . htmlspecialchar
 
 $_SESSION['qr'][0]['text'] = autoUrl("payments/history/statement/" . htmlspecialchars(strtoupper($PaymentID)));
 
+$billDate = null;
+try {
+  $billDate = new DateTime($payment_info['Date'], new DateTimeZone('UTC'));
+  $billDate->setTimezone(new DateTimeZone('Europe/London'));
+} catch (Exception $e) {
+  $billDate = new DateTime('now', new DateTimeZone('Europe/London'));
+}
+
 include BASE_PATH . "views/header.php";
 include BASE_PATH . "views/paymentsMenu.php";
 
  ?>
 
 <div class="container">
+  <?php if ($_SESSION['AccessLevel'] == 'Parent') { ?>
+  <nav aria-label="breadcrumb">
+    <ol class="breadcrumb">
+      <li class="breadcrumb-item"><a href="<?=autoUrl("payments")?>">Payments</a></li>
+			<li class="breadcrumb-item"><a href="<?=autoUrl("payments/transactions")?>">History</a></li>
+      <li class="breadcrumb-item active" aria-current="page"><?=htmlspecialchars($billDate->format("j M Y"))?></li>
+    </ol>
+  </nav>
+  <?php } ?>
+
 	<div class="">
     <span class="d-none d-print-block h1"><?=htmlspecialchars(env('CLUB_NAME'))?> Payments</span>
     <?php if ($_SESSION['AccessLevel'] == "Parent") { ?>
@@ -151,7 +169,6 @@ include BASE_PATH . "views/paymentsMenu.php";
   				<tbody>
   				<?php
   				do {
-  					//$row = mysqli_fetch_array($result, MYSQLI_ASSOC);
   					$data = "";
   					if ($row['MetadataJSON'] != "" || $row['MetadataJSON'] != "") {
   						$json = json_decode($row['MetadataJSON']);
@@ -159,11 +176,14 @@ include BASE_PATH . "views/paymentsMenu.php";
   							$data .= '<ul class="list-unstyled mb-0">';
   							//echo sizeof($json->Members);
   							//pre($json->Members);
-  							//echo $json->Members[0]->MemberName;
-  							$numMems = (int) sizeof($json->Members);
-  							for ($y = 0; $y < $numMems; $y++) {
-  								$data .= '<li>' . htmlspecialchars($json->Members[$y]->FeeName) . " (&pound;" . htmlspecialchars($json->Members[$y]->Fee) . ") for " . htmlspecialchars($json->Members[$y]->MemberName) . '</li>';
-  							}
+                //echo $json->Members[0]->MemberName;
+                $numMems = 0;
+                if (isset($json->Members) && $json->Members != null) {
+                  $numMems = (int) sizeof($json->Members);
+                  for ($y = 0; $y < $numMems; $y++) {
+                    $data .= '<li>' . htmlspecialchars($json->Members[$y]->FeeName) . " (&pound;" . htmlspecialchars($json->Members[$y]->Fee) . ") for " . htmlspecialchars($json->Members[$y]->MemberName) . '</li>';
+                  }
+                }
   							$data .= '</ul>';
   						}
   					}

--- a/src/controllers/payments/mybanks.php
+++ b/src/controllers/payments/mybanks.php
@@ -6,16 +6,13 @@ global $db;
 
 $user = $_SESSION['UserID'];
 $use_white_background = true;
-$pagetitle = "Payments and Direct Debits";
+$pagetitle = "Direct Debit Mandate";
 
 include BASE_PATH . "views/header.php";
 include BASE_PATH . "views/paymentsMenu.php";
 
-//$customers = $client->customers()->list()->records;
-//print_r($customers);
-
 /*
- * Get the user's preferred mandate (If exists)
+ * Get the user's preferred mandate (if exists)
  */
 $getPreferred = $db->prepare("SELECT MandateID FROM `paymentPreferredMandate` WHERE `UserID` = ?");
 $getPreferred->execute([$_SESSION['UserID']]);
@@ -33,72 +30,75 @@ $mandateDetails->execute([$_SESSION['UserID'], true]);
 ?>
 
 <div class="container">
-	<h1>Bank Account Options</h1>
-	<p class="lead">Control your Direct Debit details</p>
 
-  <div class="cell">
-  	<h2>My Direct Debit Mandates</h2>
-    <p class="lead">
-      View details about your current mandates, and switch your primary mandate (the bank we take money from)
-    </p>
-    <p>
-      To delete a mandate permanently, contact your bank in person, by phone or through online banking, where you can cancel a mandate yourself.
-    </p>
-  	<?php if ($row = $mandateDetails->fetch(PDO::FETCH_ASSOC)) { ?>
-  	<div class="table-responsive-md bg-white">
-  		<table class="table table-striped">
-  			<thead>
-  				<tr>
-            <th>Mandate ID</th>
-  					<th>Bank Name</th>
-  					<th>Account Holder</th>
-  					<th>Account Number</th>
-            <th></th>
-  				</tr>
-  			</thead>
-  			<tbody>
-  				<?php do { ?>
-  				<tr>
-            <td class="mono">
-              <a target="_blank" href="<?=autoUrl("payments/mandates/" . htmlspecialchars($row['Mandate']))?>" title="View Mandate Details">
-                <?=htmlspecialchars($row['Mandate'])?>
-              </a>
-            </td>
-  					<td>
-              <?=htmlspecialchars(getBankName($row['BankName']))?>
-            </td>
-  					<td class="mono" title="Name on bank account">
-              <?=htmlspecialchars($row['AccountHolderName'])?>
-            </td>
-            <td class="mono" title="Last two digits of your account number">
-              ******<?=htmlspecialchars($row['AccountNumEnd'])?>
-            </td>
-  					<?php if ($defaultAcc != null > 1 && $defaultAcc != $row['MandateID']) { ?>
-  					<td>
-              <a href="<?=autoUrl("payments/mandates/makedefault/" . htmlspecialchars($row['MandateID']))?>">
-                Make Default
-              </a>
-            </td>
-  					<?php } else { ?>
-  					<td>
-              <small>Default Mandate</small>
-            </td>
-  					<?php } ?>
-  				</tr>
-  			<?php } while ($row = $mandateDetails->fetch(PDO::FETCH_ASSOC)); ?>
-  			</tbody>
-  		</table>
-  	</div>
-    <p class="mb-0">
-      <a href="<?=autoUrl("payments/setup")?>" class="btn btn-dark">
-        Setup New Direct Debit
-      </a>
-    </p>
+  <nav aria-label="breadcrumb">
+    <ol class="breadcrumb">
+      <li class="breadcrumb-item"><a href="<?=autoUrl("payments")?>">Payments</a></li>
+      <li class="breadcrumb-item active" aria-current="page">Bank</li>
+    </ol>
+  </nav>
+
+	<h1>Bank Account Options</h1>
+  <p class="lead">
+    Your Direct Debit Mandate is an agreement with your bank allowing us to take payments.
+  </p>
+  <p>
+    To canel a mandate, contact your bank in person, by phone or through online banking, where you can cancel a mandate yourself.
+  </p>
+  <?php if ($row = $mandateDetails->fetch(PDO::FETCH_ASSOC)) { ?>
+  <div class="table-responsive-md bg-white">
+    <table class="table table-striped">
+      <thead>
+        <tr>
+          <th>Mandate ID</th>
+          <th>Bank Name</th>
+          <th>Account Holder</th>
+          <th>Account Number</th>
+          <th></th>
+        </tr>
+      </thead>
+      <tbody>
+        <?php do { ?>
+        <tr>
+          <td class="mono">
+            <a target="_blank" href="<?=autoUrl("payments/mandates/" . htmlspecialchars($row['Mandate']))?>" title="View Mandate Details">
+              <?=htmlspecialchars($row['Mandate'])?>
+            </a>
+          </td>
+          <td>
+            <?=htmlspecialchars(getBankName($row['BankName']))?>
+          </td>
+          <td class="mono" title="Name on bank account">
+            <?=htmlspecialchars($row['AccountHolderName'])?>
+          </td>
+          <td class="mono" title="Last two digits of your account number">
+            ******<?=htmlspecialchars($row['AccountNumEnd'])?>
+          </td>
+          <?php if ($defaultAcc != null > 1 && $defaultAcc != $row['MandateID']) { ?>
+          <td>
+            <a href="<?=autoUrl("payments/mandates/makedefault/" . htmlspecialchars($row['MandateID']))?>">
+              Make Default
+            </a>
+          </td>
+          <?php } else { ?>
+          <td>
+            <small>Default Mandate</small>
+          </td>
+          <?php } ?>
+        </tr>
+      <?php } while ($row = $mandateDetails->fetch(PDO::FETCH_ASSOC)); ?>
+      </tbody>
+    </table>
   </div>
+  <p class="mb-0">
+    <a href="<?=autoUrl("payments/setup")?>" class="btn btn-success">
+      Setup New Direct Debit
+    </a>
+  </p>
 	<?php } else { ?>
 	<div class="alert alert-warning">
-		<strong>You have no Direct Debit Mandates</strong> <br>
-		<a class="alert-link" href="<?=autoUrl("payments/setup")?>">Create one now</a>
+		<strong>You do not have a direct debit set up</strong> <br>
+		<a class="alert-link" href="<?=autoUrl("payments/setup")?>">Set one up now</a>
 	</div>
 	<?php } ?>
 </div>

--- a/src/controllers/payments/parent/currentfees.php
+++ b/src/controllers/payments/parent/currentfees.php
@@ -12,6 +12,14 @@ include BASE_PATH . "views/paymentsMenu.php";
 ?>
 
 <div class="container">
+	<?php if ($_SESSION['AccessLevel'] == 'Parent') { ?>
+  <nav aria-label="breadcrumb">
+    <ol class="breadcrumb">
+      <li class="breadcrumb-item"><a href="<?=autoUrl("payments")?>">Payments</a></li>
+      <li class="breadcrumb-item active" aria-current="page">Latest fees</li>
+    </ol>
+  </nav>
+  <?php } ?>
 	<div class="row">
     <div class="col-md-8">
   		<h1 class="">Charges since last bill</h1>

--- a/src/controllers/payments/parent/transactions.php
+++ b/src/controllers/payments/parent/transactions.php
@@ -13,6 +13,14 @@ include BASE_PATH . "views/paymentsMenu.php";
 ?>
 
 <div class="container">
+
+	<nav aria-label="breadcrumb">
+    <ol class="breadcrumb">
+      <li class="breadcrumb-item"><a href="<?=autoUrl("payments")?>">Payments</a></li>
+      <li class="breadcrumb-item active" aria-current="page">History</li>
+    </ol>
+  </nav>
+
 	<div class="">
 		<h1 class="">Transaction History</h1>
 		<p class="lead">Previous Payments and Refunds</p>

--- a/src/controllers/payments/setup/start.php
+++ b/src/controllers/payments/setup/start.php
@@ -19,6 +19,13 @@ if ($scheduleExists > 0) {
 	$scheduleExists = false;
 }
 
+// Get count mandates
+$getCount = $db->prepare("SELECT COUNT(*) FROM paymentMandates WHERE UserID = ? AND InUse = 1");
+$getCount->execute([
+	$_SESSION['UserID']
+]);
+$mandateCount = $getCount->fetchColumn();
+
 $pagetitle = "Set up a Direct Debit";
 
 include BASE_PATH . "views/header.php";
@@ -26,21 +33,56 @@ include BASE_PATH . "views/paymentsMenu.php";
  ?>
 
 <div class="container">
+
+	<?php if (!isset($renewal_trap) || !$renewal_trap) { ?>
+	<nav aria-label="breadcrumb">
+    <ol class="breadcrumb">
+      <li class="breadcrumb-item"><a href="<?=autoUrl("payments")?>">Payments</a></li>
+			<li class="breadcrumb-item"><a href="<?=autoUrl("payments/mandates")?>">Bank</a></li>
+      <li class="breadcrumb-item active" aria-current="page">New</li>
+    </ol>
+  </nav>
+	<?php } ?>
+
 	<div class="row">
-		<div class="col-lg-6">
-			<div class="">
+		<div class="col-lg-8">
+			<div class="mb-3">
 				<h1>Setup a Direct Debit to pay <?=htmlspecialchars(env('CLUB_NAME'))?></h1>
 				<p class="lead">
-					Payments to <?=htmlspecialchars(env('CLUB_NAME'))?> are now moving to direct debit.
+					Direct Debit is the easiest way to pay your club fees.
+				</p>
+
+				<?php if ($mandateCount > 0) { ?>
+				<div class="alert alert-info">
+					<p class="mb-0">
+						<strong>Please do not set up a new direct debit if you are switching current accounts with the <a class="alert-link" href="https://www.currentaccountswitch.co.uk">Current Account Switch Service</a>!</strong>
+					</p>
+					<p class="mb-0">
+						We'll automatically update your details to your new bank when the switch goes through.
+					</p>
+				</div>
+				<?php } ?>
+
+				<h2>To begin, you will need</h2>
+				<ul>
+					<li>The name of the bank account holder</li>
+					<li>Your sort code and bank account number</li>
+					<li>The address of the bank account holder</li>
+				</ul>
+
+				<p>You must be authorised to create a direct debit mandate on the account.</p>
+
+				<h2>You will not need</h2>
+				<ul>
+					<li>The name or address of your bank - we'll fetch this automatically</li>
+					<li>A second approval for most joint accounts - one person is almost always sufficient for approval</li>
+				</ul>
+
+				<p>
+					Direct Debit makes payments simpler for everyone involved. Payments are taken automatically, so there is no need to adjust standing orders and payments are automatically marked as paid by our systems.
 				</p>
 				<p>
-					Direct Debit makes payments simpler for everyone involved. You no
-					longer need to pay by standing order or cheque as payments will be
-					taken automatically.
-				</p>
-				<p>
-					We'll generally charge you your fees on or soon after the first
-					working day of each month.
+					We'll usually generate a bill and charge you your fees on or soon after the first working day of each month. It can take several days for the money to leave your bank account.
 				</p>
 				<p class=""><a href="
 					<?php
@@ -51,64 +93,57 @@ include BASE_PATH . "views/paymentsMenu.php";
 					} ?>
 					" class="btn btn-success">Setup a Direct Debit</a>
 				</p>
-				<?php if ($scheduleExists) { ?>
-				<p class="small mb-0">
-					We'll direct you to our partner GoCardless who handle Direct Debits on
-					our behalf.
-				</p>
-				<?php } else { ?>
 				<p class="small mb-0">This won't take long.</p>
-				<?php } ?>
 			</div>
 		</div>
 		<div class="col">
 			<div class="cell">
-				<p class="text-center">
-					<img style="max-height:50px;" src="<?php echo
-					autoUrl("public/img/directdebit/directdebit.png"); ?>" srcset="<?php echo
-					autoUrl("public/img/directdebit/directdebit@2x.png"); ?> 2x, <?php echo
-					autoUrl("public/img/directdebit/directdebit@3x.png"); ?> 3x" alt="Direct
-					Debit Logo">
-				</p>
-				<p>
-					The Direct Debit Guarantee applies to payments made to
-					<?=htmlspecialchars(env('CLUB_NAME'))?>
-				</p>
-				<ul>
-					<li>
-						This Guarantee is offered by all banks and building societies that
-						accept instructions to pay Direct Debits
-					</li>
-					<li>
-						If there are any changes to the amount, date or frequency of your
-						Direct Debit <?=htmlspecialchars(env('CLUB_NAME'))?> will notify you three working
-						days in advance of your account being debited or as otherwise
-						agreed. If you request <?=htmlspecialchars(env('CLUB_NAME'))?> to collect a payment,
-						confirmation of the amount and date will be given to you at the time
-						of the request
-					</li>
-					<li>
-						If an error is made in the payment of your Direct Debit, by
-						<?=htmlspecialchars(env('CLUB_NAME'))?> or your bank or building society, you are
-						entitled to a full and immediate refund of the amount paid from your
-						bank or building society
-						<ul>
-							<li>
-								If you receive a refund you are not entitled to, you must pay it
-								back when <?=htmlspecialchars(env('CLUB_NAME'))?> asks you to
-							</li>
-						</ul>
-					</li>
-					<li>
-						You can cancel a Direct Debit at any time by simply contacting your
-						bank or building society. Written confirmation may be required.
-						Please also notify us.
-					</li>
-				</ul>
-        <p class="mb-0">Payments are handled by GoCardless on behalf of
-        <?=htmlspecialchars(env('CLUB_NAME'))?>.</p>
-			</div>
+			<p class="text-center">
+				<img style="max-height:50px;" src="<?php echo
+				autoUrl("public/img/directdebit/directdebit.png"); ?>" srcset="<?php echo
+				autoUrl("public/img/directdebit/directdebit@2x.png"); ?> 2x, <?php echo
+				autoUrl("public/img/directdebit/directdebit@3x.png"); ?> 3x" alt="Direct
+				Debit Logo">
+			</p>
+			<p>
+				The Direct Debit Guarantee applies to payments made to
+				<?=htmlspecialchars(env('CLUB_NAME'))?>
+			</p>
+			<ul>
+				<li>
+					This Guarantee is offered by all banks and building societies that
+					accept instructions to pay Direct Debits
+				</li>
+				<li>
+					If there are any changes to the amount, date or frequency of your
+					Direct Debit <?=htmlspecialchars(env('CLUB_NAME'))?> will notify you three working
+					days in advance of your account being debited or as otherwise
+					agreed. If you request <?=htmlspecialchars(env('CLUB_NAME'))?> to collect a payment,
+					confirmation of the amount and date will be given to you at the time
+					of the request
+				</li>
+				<li>
+					If an error is made in the payment of your Direct Debit, by
+					<?=htmlspecialchars(env('CLUB_NAME'))?> or your bank or building society, you are
+					entitled to a full and immediate refund of the amount paid from your
+					bank or building society
+					<ul>
+						<li>
+							If you receive a refund you are not entitled to, you must pay it
+							back when <?=htmlspecialchars(env('CLUB_NAME'))?> asks you to
+						</li>
+					</ul>
+				</li>
+				<li>
+					You can cancel a Direct Debit at any time by simply contacting your
+					bank or building society. Written confirmation may be required.
+					Please also notify us.
+				</li>
+			</ul>
+			<p class="mb-0">Payments are handled by GoCardless on behalf of
+			<?=htmlspecialchars(env('CLUB_NAME'))?>.</p>
 		</div>
+	</div>
 	</div>
 </div>
 

--- a/src/controllers/payments/user.php
+++ b/src/controllers/payments/user.php
@@ -32,6 +32,13 @@ include BASE_PATH . "views/paymentsMenu.php";
 -->
 
 <div class="container">
+
+  <nav aria-label="breadcrumb">
+    <ol class="breadcrumb">
+      <li class="breadcrumb-item active" aria-current="page">Payments</li>
+    </ol>
+  </nav>
+
   <div class="row align-items-center">
     <div class="col-md-6 col-lg-8">
     	<h1>Payments</h1>
@@ -77,9 +84,10 @@ include BASE_PATH . "views/paymentsMenu.php";
           <p><?=htmlspecialchars(env('CLUB_NAME'))?> does not store your bank details.</p>
         <?php } ?>
         <p class="mb-0">
-        	<a href="<?=autoUrl("payments/setup")?>" class="btn btn-dark btn-block">Add Bank Account</a>
           <?php if (userHasMandates($user)) { ?>
-        	<a href="<?=autoUrl("payments/mandates")?>" class="btn btn-dark btn-block">Switch or Manage Bank Account</a>
+        	<a href="<?=autoUrl("payments/mandates")?>" class="btn btn-dark btn-block">Manage your bank account</a>
+          <?php } else { ?>
+          <a href="<?=autoUrl("payments/setup")?>" class="btn btn-dark btn-block">Setup a Direct Debit</a>
           <?php } ?>
         </p>
       </div>


### PR DESCRIPTION
Allows only one direct debit mandate at a time so when you set up a new one, it is definitively your direct debit.

Improves user experience.

Fixes #197.